### PR TITLE
Page permalinks

### DIFF
--- a/app/App/Traits/HasPath.php
+++ b/app/App/Traits/HasPath.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Cms\App\Traits;
+
+use Illuminate\Database\Eloquent\Model;
+
+trait HasPath {
+
+    protected static function bootHasPath(): void
+    {
+        static::creating(function (Model $model) {
+            // TODO: Initially, the path is generated from the slug alone.
+
+            $model->uri = implode('/', [$model->path, $model->slug]);
+        });
+
+        static::updating(function (Model $model) {
+            // TODO: Eventually you might need to generate your slug from
+            // other model properties. For this, consider a pipeline, "generateSlugPipline".
+            // The pipeline accept the model properties to be used e.g., title, category, published date.
+
+            if ($model->isDirty('slug') || $model->isDirty('path')) {
+                $model->uri = $model->generateUriFromParts([$model->path, $model->slug]);
+            }
+        });
+    }
+
+    protected function generateUriFromParts(array $parts): string
+    {
+        $uri = implode('/', $parts);
+
+        return $uri;
+    }
+}

--- a/app/App/Traits/HasSlug.php
+++ b/app/App/Traits/HasSlug.php
@@ -11,17 +11,20 @@ trait HasSlug {
     {
         static::creating(function (Model $model) {
             $slug = Str::slug($model->title);
-            $model->slug = $model->makeSlugUnique($slug);
+            $model->slug = $model->generateUniqueSlug($slug);
         });
+
+        // TODO: After "updated" event, we might check that the slug is still unique
+        // static::updated(function (Model $model) {});
     }
 
-    protected function makeSlugUnique(string $slug): string
+    protected function generateUniqueSlug(string $slug): string
     {
-        $original_slug = $slug;
-        $i = 2;
+        $baseSlug = $slug;
 
+        $i = 2;
         while ($this->otherRecordsExistWithSlug($slug)) {
-            $slug = $original_slug . '-' . $i++;
+            $slug = $baseSlug . '-' . $i++;
         }
 
         return $slug;

--- a/app/Domain/Pages/Page.php
+++ b/app/Domain/Pages/Page.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\Builder;
 
 // Traits
 use Cms\App\Traits\HasSlug;
+use Cms\App\Traits\HasPath;
 use Cms\App\Traits\IsBlueprint;
 
 // Filters
@@ -15,9 +16,12 @@ use Cms\Domain\Pages\Filters\PageFilters;
 
 class Page extends Model
 {
-    use HasFactory, HasSlug, IsBlueprint;
+    use HasFactory,
+        HasSlug,
+        HasPath,
+        IsBlueprint;
 
-    protected $guarded = ['id', 'slug'];
+    protected $guarded = ['id'];
 
     protected $table = 'pages';
 

--- a/app/Http/Pages/PageCheckSlugController.php
+++ b/app/Http/Pages/PageCheckSlugController.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Cms\Http\Pages;
+
+use Illuminate\Http\Request;
+use Cms\App\Controllers\Controller;
+
+// Domains
+use Cms\Domain\Pages\Page;
+
+// Requests
+use Cms\Http\Pages\Requests\PageCheckSlugRequest;
+
+class PageCheckSlugController extends Controller
+{
+    public function show(PageCheckSlugRequest $request)
+    {
+        $query = Page::where('slug', '=', $request->slug);
+
+        return response()->json([
+            'data' => [
+                'unique' => !$query->exists(),
+
+                // TODO: Maybe also return the page resource using slug if not unique
+            ]
+        ]);
+    }
+}

--- a/app/Http/Pages/PageController.php
+++ b/app/Http/Pages/PageController.php
@@ -14,7 +14,8 @@ use Cms\Http\Pages\Resources\PageResource;
 use Cms\Http\Pages\Resources\PageCollection;
 
 // Requests
-// use App\Http\Requests\PageStoreRequest;
+use Cms\Http\Pages\Requests\PageStoreRequest;
+use Cms\Http\Pages\Requests\PageUpdateRequest;
 
 class PageController extends Controller
 {
@@ -31,12 +32,10 @@ class PageController extends Controller
         return new PageCollection($pages);
     }
 
-    public function store(Organization $organization, Request $request)
+    public function store(Organization $organization, PageStoreRequest $request)
     {
         $page = $organization->pages()->create(
-            // TODO: Use FormRequest for request validation
-            // $request->validated()
-            $request->all()
+            $request->validated()
         );
 
         return new PageResource($page);
@@ -53,12 +52,10 @@ class PageController extends Controller
         );
     }
 
-    public function update(Organization $organization, Page $page, Request $request)
+    public function update(Organization $organization, Page $page, PageUpdateRequest $request)
     {
         $page->update(
-            // TODO: Use FormRequest for request validation
-            // $request->validated()
-            $request->all()
+            $request->validated()
         );
 
         return new PageResource($page);

--- a/app/Http/Pages/Requests/PageCheckSlugRequest.php
+++ b/app/Http/Pages/Requests/PageCheckSlugRequest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Cms\Http\Pages\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Http\Exceptions\HttpResponseException;
+
+class PageCheckSlugRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'slug' => 'required|string',
+        ];
+    }
+
+    /**
+     * Return exception as json
+     *
+     * @return Exception
+     */
+    protected function failedValidation(Validator $validator)
+    {
+        throw new HttpResponseException(response()->json($validator->errors(), 422));
+    }
+}

--- a/app/Http/Pages/Requests/PageStoreRequest.php
+++ b/app/Http/Pages/Requests/PageStoreRequest.php
@@ -3,6 +3,8 @@
 namespace Cms\Http\Pages\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Http\Exceptions\HttpResponseException;
 
 class PageStoreRequest extends FormRequest
 {
@@ -24,10 +26,17 @@ class PageStoreRequest extends FormRequest
     public function rules()
     {
         return [
-            'title'       => 'nullable|string',
-            'category_id' => 'nullable|integer',
-            'type_id'     => 'nullable|integer',
-            'layout_id'   => 'nullable|integer'
+            'title' => 'required|string'
         ];
+    }
+
+    /**
+     * Return exception as json
+     *
+     * @return Exception
+     */
+    protected function failedValidation(Validator $validator)
+    {
+        throw new HttpResponseException(response()->json($validator->errors(), 422));
     }
 }

--- a/app/Http/Pages/Requests/PageUpdateRequest.php
+++ b/app/Http/Pages/Requests/PageUpdateRequest.php
@@ -6,7 +6,7 @@ use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Http\Exceptions\HttpResponseException;
 
-class ReplicatePageStoreRequest extends FormRequest
+class PageUpdateRequest extends FormRequest
 {
     /**
      * Determine if the user is authorized to make this request.
@@ -26,7 +26,11 @@ class ReplicatePageStoreRequest extends FormRequest
     public function rules()
     {
         return [
-            'is_blueprint' => 'required|boolean'
+            'title'        => 'nullable|string',
+            'slug'         => 'nullable|string|unique:pages,slug', // TODO: Create custom slug rule (foo-bar)
+            'path'         => 'nullable|string', // TODO: Create custom path rule (foo/bar)
+            'category_id'  => 'nullable|integer',
+            'is_published' => 'nullable|integer'
         ];
     }
 

--- a/app/Http/Pages/Resources/PageResource.php
+++ b/app/Http/Pages/Resources/PageResource.php
@@ -22,7 +22,8 @@ class PageResource extends JsonResource
             'id' => $this->id,
             'title' => $this->title,
             'slug' => $this->slug,
-            'is_blueprint' => $this->is_blueprint,
+            'path' => $this->path,
+            'uri' => $this->uri,
             'is_published' => $this->is_published,
             'category' => new CategoryResource($this->whenLoaded('category')),
             'layout' => new LayoutResource($this->whenLoaded('layout'))

--- a/database/migrations/2020_11_23_300000_create_pages_table.php
+++ b/database/migrations/2020_11_23_300000_create_pages_table.php
@@ -16,9 +16,17 @@ class CreatePagesTable extends Migration
         Schema::create('pages', function (Blueprint $table) {
             $table->id();
             $table->string('title');
+
+            // URL
             $table->string('slug')->unique();
+            $table->string('path')->nullable();
+            $table->string('uri')->nullable();
+
+            // Relations
             $table->foreignId('organization_id');
             $table->foreignId('category_id')->nullable();
+
+            // State
             $table->boolean('is_published')->default(false);
             $table->boolean('is_blueprint')->default(false);
             $table->timestamps();

--- a/routes/api.php
+++ b/routes/api.php
@@ -8,8 +8,9 @@ use Organizations\OrganizationController;
 
 // Pages
 use Pages\PageController;
-use Cms\Http\Pages\PageBlueprintController;
 use Cms\Http\Pages\PageReplicateController;
+use Cms\Http\Pages\PageBlueprintController;
+use Cms\Http\Pages\PageCheckSlugController;
 
 // Layouts
 use Layouts\LayoutController;
@@ -44,8 +45,9 @@ Route::apiResource('organizations', OrganizationController::class);
 
 // Pages
 Route::apiResource('organizations.pages', PageController::class);
-Route::get('organizations/{organization}/page-blueprints', [PageBlueprintController::class, 'index']);
 Route::post('organizations/{organization}/pages/{page}/replicate', [PageReplicateController::class, 'replicate']);
+Route::get('organizations/{organization}/page-blueprints', [PageBlueprintController::class, 'index']);
+Route::get('organizations/{organization}/page/check-slug', [PageCheckSlugController::class, 'show']);
 
 // Layouts
 Route::apiResource('organizations.layouts', LayoutController::class);


### PR DESCRIPTION
Add permalink functionality to pages. Page slug is generated automatically from title, but not updated on future title changes. Page path is editable at any time. Both slug and path are combined to create the page URI. The URI is what should be used locate pages from consuming clients (E.g., Nuxt).